### PR TITLE
correction for macro set_attribute in html.juno

### DIFF
--- a/pkg/html.juno
+++ b/pkg/html.juno
@@ -117,7 +117,7 @@
    })
 
 (defmacro set_attribute (elem attrib value)
-   `(-> ,#elem `getAttribute ,#attrib ,#value)
+   `(-> ,#elem `setAttribute ,#attrib ,#value)
    {
      description: (+ "Given a DOM Element, attribute text and value, sets "
                      "the provided attribute to the value on the element. "


### PR DESCRIPTION
I believe there is mistake in set_attribute macro.